### PR TITLE
コンテナのprofileが存在しない場合, エラーメッセージに表示させる

### DIFF
--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -139,7 +139,7 @@ def start(client,
         container = client.containers.get(container_name)
         write_env(container, env)
     except pylxd.exceptions.NotFound:
-        if subprocess.run(['lxd', 'profile', 'show', container_profile]).returncode == 1:
+        if subprocess.run(['lxc', 'profile', 'show', container_profile]).returncode == 1:
             return False
 
         container = launch(client, container_name, container_profile,

--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -139,6 +139,9 @@ def start(client,
         container = client.containers.get(container_name)
         write_env(container, env)
     except pylxd.exceptions.NotFound:
+        if subprocess.run(['lxd', 'profile', 'show', container_profile]).returncode == 1:
+            return False
+
         container = launch(client, container_name, container_profile,
                            container_image_alias, cmd, env, cpu_limit, mem_limit)
 
@@ -259,6 +262,9 @@ class LXDSpawner(Spawner):
             self.ip = result[0]
             self.port = result[1]
             return (self.ip, self.port)
+        elif result == False:
+            self.log.error('container profile: % s does not exist',
+                           self.container_profile)
 
         return None
 

--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -139,7 +139,7 @@ def start(client,
         container = client.containers.get(container_name)
         write_env(container, env)
     except pylxd.exceptions.NotFound:
-        if subprocess.run(['lxc', 'profile', 'show', container_profile]).returncode == 1:
+        if not client.profiles.exists(container_profile):
             return False
 
         container = launch(client, container_name, container_profile,

--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -131,7 +131,8 @@ def start(client,
           env,
           start_timeout,
           cpu_limit,
-          mem_limit):
+          mem_limit,
+          logger):
     """
     start starts a LXD container running the jupyterhub-singleuser program.
     """
@@ -140,7 +141,9 @@ def start(client,
         write_env(container, env)
     except pylxd.exceptions.NotFound:
         if not client.profiles.exists(container_profile):
-            return False
+            logger.error('container profile: % s does not exist',
+                         container_profile)
+            return None
 
         container = launch(client, container_name, container_profile,
                            container_image_alias, cmd, env, cpu_limit, mem_limit)
@@ -255,16 +258,14 @@ class LXDSpawner(Spawner):
             self.get_env(),
             self.start_timeout,
             self.cpu_limit,
-            self.mem_limit
+            self.mem_limit,
+            self.log
         )
 
         if result:
             self.ip = result[0]
             self.port = result[1]
             return (self.ip, self.port)
-        elif result == False:
-            self.log.error('container profile: % s does not exist',
-                           self.container_profile)
 
         return None
 


### PR DESCRIPTION
# WHAT

profileが存在しない場合

```container profile: jupyterhub-singleuser-testee does not exist```

のようなエラーメッセージをjournalctlのログで表示