### PR TITLE
ユーザコンテナのGPU利用を一個に制限

### DIFF
--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -157,7 +157,8 @@ def start(client,
     else:
         # PCIアドレスを指定して専有
         try:
-            r = requests.get(iris_url)
+            # ex: http://iris-tippy.lxd
+            r = requests.get("{}-{}.lxd".format(iris_url, container.location))
             r.raise_for_status()
         except requests.exceptions.HTTPError:
             logger.error('iris api server error, Status Code: % d',

--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -4,6 +4,7 @@ import math
 import re
 import subprocess
 import time
+import requests
 
 import pylxd
 from jupyterhub.spawner import Spawner
@@ -132,7 +133,8 @@ def start(client,
           start_timeout,
           cpu_limit,
           mem_limit,
-          logger):
+          logger,
+          iris_url):
     """
     start starts a LXD container running the jupyterhub-singleuser program.
     """
@@ -149,8 +151,21 @@ def start(client,
                            container_image_alias, cmd, env, cpu_limit, mem_limit)
 
     if container.status == "Running":
+        # 既にコンテナが動いている場合グラボを専有していると前提
         container.execute(["systemctl", "restart", "jupyterhub-singleuser"])
     else:
+        # PCIアドレスを指定して専有
+        try:
+            r = requests.get(iris_url)
+            r.raise_for_status()
+        except requests.exceptions.HTTPError:
+            logger.error('iris api server error, Status Code: % d',
+                         r.status_code)
+            return None
+
+        vacant_gpu_pci = r.json()['Pci']
+        container.devices = {'gpu': {'type': 'gpu', 'pci': vacant_gpu_pci}}
+        container.save()
         container.start()
 
     # Wait for the single-user process to be running, which implies that the
@@ -195,6 +210,11 @@ class LXDSpawner(Spawner):
     container_image_alias = Unicode(
         config=True,
         help='Client image alias for single user\' container'
+    )
+
+    iris_url = Unicode(
+        config=True,
+        help='Iris Application URL'
     )
 
     def __init__(self, *args, **kwargs):
@@ -259,7 +279,8 @@ class LXDSpawner(Spawner):
             self.start_timeout,
             self.cpu_limit,
             self.mem_limit,
-            self.log
+            self.log,
+            self.iris_url
         )
 
         if result:
@@ -282,4 +303,3 @@ class LXDSpawner(Spawner):
     @gen.coroutine
     def poll(self):
         return poll(self.client, self.container_name)
-

--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -147,6 +147,7 @@ def start(client,
                          container_profile)
             return None
 
+        # GPUの存在関係なくコンテナを作成
         container = launch(client, container_name, container_profile,
                            container_image_alias, cmd, env, cpu_limit, mem_limit)
 
@@ -164,6 +165,11 @@ def start(client,
             return None
 
         vacant_gpu_pci = r.json()['Pci']
+
+        if vacant_gpu_pci == '':
+            logger.error('can\'t allocate gpu')
+            return None
+
         container.devices = {'gpu': {'type': 'gpu', 'pci': vacant_gpu_pci}}
         container.save()
         container.start()

--- a/lxdspawner/spawner.py
+++ b/lxdspawner/spawner.py
@@ -165,7 +165,7 @@ def start(client,
                          r.status_code)
             return None
 
-        vacant_gpu_pci = r.json()['Pci']
+        vacant_gpu_pci = r.json()['pci']
 
         if vacant_gpu_pci == '':
             logger.error('can\'t allocate gpu')


### PR DESCRIPTION
# 関係するIssue

#10 

# 関係するPullRequest

[https://github.com/KeioAIConsortium/iris/pull/1](https://github.com/KeioAIConsortium/iris/pull/1)

[https://github.com/KeioAIConsortium/ai_room/pull/73](https://github.com/KeioAIConsortium/ai_room/pull/73)

# WHAT

- [x] Iris呼び出し実装
- [x] GPU制限実装
- [x] jupyterhub_config.pyの書き換え
- [x] GPU制限のテスト 
  - [x] GPUが余っている場合、新しく起動するコンテナがGPUを専有
  - [x] GPUを専有したコンテナ上でtensorflowを用いた機械学習
  - [x] 他のコンテナにすべてのGPUを専有されてしまった場合新しいコンテナを立ち上げ時にエラーを吐く(`can't allocate gpu`)
  - [x] あるGPUが別のコンテナに専有された場合、他のコンテナからそのGPUが見えないようになっている


専有した場合、`lxc config show コンテナ名`で

```
  gpu:
    pci: "0000:02:00.0"
    type: gpu
```

と確認された。